### PR TITLE
migrate prosody from init.d to systemd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ molecule/*/.molecule
 .tox
 .vagrant
 tests/__pycache__
+
+# Git files
+.gitconfig

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -83,7 +83,7 @@ prosody_s2s_blacklist:
 
 prosody_blacklist: []
 
-prosody_file_limit: []
+prosody_file_limit: false
 
 prosody_limits: true
 prosody_limits_c2s_rate: "3kb/s"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -83,7 +83,7 @@ prosody_s2s_blacklist:
 
 prosody_blacklist: []
 
-prosody_file_limit: false
+prosody_file_limit: []
 
 prosody_limits: true
 prosody_limits_c2s_rate: "3kb/s"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,13 +1,32 @@
 ---
-- name: reload prosody config
+- name: stop init.d prosody
   service:
+    name: prosody
+    state: stopped
+
+- name: reload systemd
+  systemd:
+    daemon_reload: true
+
+- name: reload prosody config
+  systemd:
     name: prosody
     state: reloaded
 
 - name: restart prosody
-  service:
+  systemd:
     name: prosody
     state: restarted
+
+- name: stop prosody
+  systemd:
+    name: prosody
+    state: stopped
+
+- name: start prosody
+  systemd:
+    name: prosody
+    state: started
 
 - name: restart munin-node
   service:
@@ -23,3 +42,5 @@
   service:
     name: saslauthd
     state: restarted
+
+

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -42,5 +42,3 @@
   service:
     name: saslauthd
     state: restarted
-
-

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -1,8 +1,7 @@
 ---
 - name: Install monitoring dependencies
   apt:
-    name: "{{ item }}"
-  with_items: "{{ prosody_monitoring_packages }}"
+    name: "{{ prosody_monitoring_packages }}"
   tags:
     - munin-node
     - monit

--- a/tasks/prosody.yml
+++ b/tasks/prosody.yml
@@ -24,13 +24,25 @@
 - name: Ensure required packages are present
   apt:
     pkg: "{{ prosody_packages }}"
+  notify:
+    - stop init.d prosody
 
-- name: Increase file limit
-  lineinfile:
-    dest: /etc/init.d/prosody
-    line: "MAXFDS={{ prosody_file_limit }}"
-    regexp: "^MAXFDS="
-  when: prosody_file_limit
+- name: Copy systemd service file
+  template:
+    src: prosody.service.j2
+    dest: /etc/systemd/system/prosody.service
+    mode: 0644
+    owner: root
+    group: root
+  notify:
+    - reload systemd
+    - stop prosody
+    - start prosody
+
+- name: delete init.d startup file
+  file:
+    state: absent
+    path: /etc/init.d/prosody
 
 - name: Get latest registration theme
   git:
@@ -80,6 +92,14 @@
     - certs-jabber
   notify: reload prosody config
 
+- name: Change ownership of generic key file of no custom is used
+  file:
+    path: /etc/prosody/certs/localhost.key
+    owner: root
+    group: prosody
+    mode: 0640
+  when: prosody_proxy_ssl_cert is not defined
+
 - name: Push proxy TLS key to /etc/prosody/certs/
   copy:
     content: "{{ prosody_proxy_ssl_key }}"
@@ -93,6 +113,6 @@
   notify: reload prosody config
 
 - name: Enable prosody service
-  service:
+  systemd:
     name: prosody
     enabled: true

--- a/tasks/prosody.yml
+++ b/tasks/prosody.yml
@@ -92,7 +92,7 @@
     - certs-jabber
   notify: reload prosody config
 
-- name: Change ownership of generic key file of no custom is used
+- name: Change ownership of generic key file if no custom is used
   file:
     path: /etc/prosody/certs/localhost.key
     owner: root

--- a/templates/prosody.cfg.lua.j2
+++ b/templates/prosody.cfg.lua.j2
@@ -165,6 +165,9 @@ s2s_secure_auth = false
 -- Required for init scripts and prosodyctl
 pidfile = "/var/run/prosody/prosody.pid"
 
+-- let systemd daemonize the server
+daemonize = false
+
 -- Select the authentication backend to use. The 'internal' providers
 -- use Prosody's configured data storage to store the authentication data.
 

--- a/templates/prosody.service.j2
+++ b/templates/prosody.service.j2
@@ -1,0 +1,78 @@
+# this file is from /usr/local/share/prosody-modules/misc/systemd/
+
+[Unit]
+### see man systemd.unit
+Description=Prosody XMPP Server
+Documentation=https://prosody.im/doc
+
+[Service]
+### See man systemd.service ###
+# With this configuration, systemd takes care of daemonization
+# so Prosody should be configured with daemonize = false
+Type=simple
+
+# Not sure if this is needed for 'simple'
+PIDFile=/var/run/prosody/prosody.pid
+
+# Start by executing the main executable
+ExecStart=/usr/bin/prosody
+
+ExecReload=/bin/kill -HUP $MAINPID
+
+# Restart on crashes
+Restart=on-abnormal
+
+# Set O_NONBLOCK flag on sockets passed via socket activation
+NonBlocking=true
+
+### See man systemd.exec ###
+
+WorkingDirectory=/var/lib/prosody
+
+User=prosody
+Group=prosody
+
+UMask=0027
+
+# Nice=0
+
+# Set stdin to /dev/null since Prosody does not need it
+StandardInput=null
+
+# Direct stdout/-err to journald for use with log = "*stdout"
+StandardOutput=journal
+StandardError=inherit
+
+# This usually defaults to 4000 or so
+# LimitNOFILE=20000
+
+{% if prosody_file_limit %}
+LimitNOFILE={{ prosody_file_limit }}
+{% endif %}
+
+## Interesting protection methods
+# Finding a useful combo of these settings would be nice
+#
+# Needs read access to /etc/prosody for config
+# Needs write access to /var/lib/prosody for storing data (for internal storage)
+# Needs write access to /var/log/prosody for writing logs (depending on config)
+# Needs read access to code and libraries loaded
+
+# ReadWriteDirectories=/var/lib/prosody /var/log/prosody
+# InaccessibleDirectories=/boot /home /media /mnt /root /srv
+# ReadOnlyDirectories=/usr /etc/prosody
+
+# PrivateTmp=true
+# PrivateDevices=true
+# PrivateNetwork=false
+
+# ProtectSystem=full
+# ProtectHome=true
+# ProtectKernelTunables=true
+# ProtectControlGroups=true
+# SystemCallFilter=
+
+# This should break LuaJIT
+# MemoryDenyWriteExecute=true
+
+

--- a/templates/prosody.service.j2
+++ b/templates/prosody.service.j2
@@ -1,4 +1,4 @@
-# this file is from /usr/local/share/prosody-modules/misc/systemd/
+# This file is from /usr/local/share/prosody-modules/misc/systemd/
 
 [Unit]
 ### see man systemd.unit
@@ -18,6 +18,9 @@ PIDFile=/var/run/prosody/prosody.pid
 ExecStart=/usr/bin/prosody
 
 ExecReload=/bin/kill -HUP $MAINPID
+
+RuntimeDirectory=prosody
+RuntimeDirectoryMode=0750
 
 # Restart on crashes
 Restart=on-abnormal
@@ -43,7 +46,7 @@ StandardInput=null
 StandardOutput=journal
 StandardError=inherit
 
-# This usually defaults to 4000 or so
+# This usually defaults to 4096 with systemd on Debian Stretch
 # LimitNOFILE=20000
 
 {% if prosody_file_limit %}
@@ -72,7 +75,5 @@ LimitNOFILE={{ prosody_file_limit }}
 # ProtectControlGroups=true
 # SystemCallFilter=
 
-# This should break LuaJIT
-# MemoryDenyWriteExecute=true
-
-
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
hello,
unfortunately i wasn't able to get molecule running, so I just tested locally with vagrant.

I had recently problems with the recent prosody version (memory leak) and therefore migrated from init.d to systemd to have atuo-restart functionality in case of a crash. Tha systemd prosody.service file is from prosody-modules/misc/systemd, but I copied it locally due to some minor mistakes in the file.

Moving from init.d to systemd is not that easy, prosody has to be stopped via init.d and then started (not restarted) with systemd. Therefore the handler usage is a bit messy. Maybe you can improve that.

thanks for the work, but molecule is anying. would be great if you could move back to vagrant.

