### PR TITLE
Use HTTPS to pull data via APT on Debian buster (and above)

### DIFF
--- a/tasks/prosody.yml
+++ b/tasks/prosody.yml
@@ -18,7 +18,7 @@
 
 - name: Add Prosody repository
   apt_repository:
-    repo: 'deb http://packages.prosody.im/debian {{ ansible_distribution_release }} main'
+    repo: "deb {{ 'https' if ansible_distribution == 'Debian' and ansible_distribution_major_version|int >= 10 else 'http' }}://packages.prosody.im/debian {{ ansible_distribution_release }} main"
     update_cache: true
 
 - name: Ensure required packages are present


### PR DESCRIPTION
APT >= 1.5 is able to handle HTTPS natively, no need anymore to install
apt-transport-https.