### PR TITLE
Documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Install and maintain [Prosody](http://prosody.im/) from offical repo with Ansibl
 Per default, this role also installs munin-node to monitor Prosody.
 Tested with Molecule, Docker, Vagrant and TravisCI.
 
+[Deploying Prosody using orcharhino](https://docs.orcharhino.com/or/docs/sources/usage_guides/deploying_an_internal_application_guide.html)
+
 Requirements
 ------------
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,3 +19,6 @@ galaxy_info:
       versions:
         - stretch
         - buster
+    - name: Ubuntu
+      versions:
+        - focal

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,10 +19,3 @@ galaxy_info:
       versions:
         - stretch
         - buster
-dependencies:
-  - role: systemli.apt_repositories
-    vars:
-      apt_repositories:
-        - preset: prosody
-      apt_repositories_absent:
-        - packages_prosody_im_debian.list


### PR DESCRIPTION
This PR adds a link to the [Deploying an internal application guide](https://docs.orcharhino.com/or/docs/sources/usage_guides/deploying_an_internal_application_guide.html) which uses prosody as an example for custom content and this Ansible role to configure hosts.