### PR TITLE
variable versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible-lint molecule[docker]==3.4.1 molecule-goss yamllint
+        run: pip3 install ansible-lint==5.4.0 molecule[docker]==3.4.1 molecule-goss yamllint
 
       - name: Run Molecule tests.
         run: molecule test -s docker

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: '3.x'
 
       - name: Install test dependencies.
-        run: pip3 install ansible-lint molecule[docker] molecule-goss yamllint
+        run: pip3 install ansible-lint molecule[docker]==3.4.1 molecule-goss yamllint
 
       - name: Run Molecule tests.
         run: molecule test -s docker

--- a/README.md
+++ b/README.md
@@ -86,6 +86,23 @@ molecule test
 ```
 Requires Molecule, Vagrant and `python-vagrant` to be installed.
 
+To update vars in tests run
+
+```bash
+j2 --customize ~/custom-j2.py templates/test_prosody.yml.j2 defaults/main.yml > molecule/default/tests/test_default.yml
+```
+
+```python custom-j2.py
+def j2_environment_params():
+    """ Extra parameters for the Jinja2 Environment """
+    # Jinja2 Environment configuration
+    # http://jinja.pocoo.org/docs/2.10/api/#jinja2.Environment
+    return dict(
+        # Remove whitespace around blocks
+        trim_blocks=True,
+    )
+```
+
 License
 -------
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ To update vars in tests run
 j2 --customize ~/custom-j2.py templates/test_prosody.yml.j2 defaults/main.yml > molecule/default/tests/test_default.yml
 ```
 
-```python custom-j2.py
+```python
+# ~/custom-j2.py
+
 def j2_environment_params():
     """ Extra parameters for the Jinja2 Environment """
     # Jinja2 Environment configuration

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -125,3 +125,8 @@ prosody_monitoring: true
 prosody_monitoring_packages:
   - munin-node
   - git
+
+# goss tests
+prosody_goss_prosodyctl_about_versions:
+  - Prosody 0.12
+  - Lua 5.2

--- a/molecule/default/tests/test_default.yml
+++ b/molecule/default/tests/test_default.yml
@@ -12,9 +12,11 @@ service:
 command:
   prosodyctl check config | grep -v libevent:
     exit-status: 0
+  prosodyctl check certs:
+    exit-status: 0
 
   prosodyctl about:
     exit-status: 0
     stdout:
-      - Prosody 0.11
+      - Prosody 0.12
       - Lua 5.2

--- a/templates/test_prosody.yml.j2
+++ b/templates/test_prosody.yml.j2
@@ -18,5 +18,6 @@ command:
   prosodyctl about:
     exit-status: 0
     stdout:
-      - Prosody 0.11
-      - Lua 5.2
+      {% for __test in prosody_goss_prosodyctl_about_versions -%}
+      - {{ __test }}
+      {% endfor -%}


### PR DESCRIPTION
Instead of #31 

You have to run
```
j2 --customize ~/custom-j2.py templates/test_prosody.yml.j2 defaults/main.yml > molecule/default/tests/test_default.yml
```
to update the tests.

@zxyz Do you have an idea where to document this? It is necessary for many systemli roles