### PR TITLE
fix prosody config check and syslog warning/suggestions

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,14 +21,11 @@ prosody_welcome_msg: "Hello $username, welcome to the $host IM server!"
 # once and the module keeps track of who as seen which message.
 prosody_motd: []
 
-# https://prosody.im/doc/setting_up_bosh#cross-domain_issues
-prosody_cors: False
-
 prosody_custom_registration_theme: False
 prosody_custom_registration_theme_repo: "https://github.com/beli3ver/Prosody-Web-Registration-Theme.git"
 prosody_custom_registration_theme_path: "/etc/prosody/register-templates/Prosody-Web-Registration-Theme"
 
-prosody_mod_register_redirect_registration_whitelist: ""
+prosody_mod_register_redirect_registration_allowlist: ""
 prosody_mod_register_redirect_registration_url: "https://localhost:5281/register_web"
 prosody_mod_register_redirect_text: "To register please visit {{ prosody_mod_register_redirect_registration_url}}"
 
@@ -44,7 +41,7 @@ prosody_modules:
   - carbons  # Keep multiple clients in sync
   - csi_simple  # traffic optimizations
   - mam  # Store messages in an archive and allow users to access it
-  - pep  # Allow users to publish their avatar, mood, activity, playing music and more (needed for OMEMO)
+  - pep_simple  # Allow users to publish their avatar, mood, activity, playing music and more (needed for OMEMO)
   - pep_vcard_avatar  # XEP-0398: User Avatar to vCard-Based Avatars Conversion
   - private  # Private XML storage (for room bookmarks, etc.)
   - roster  # Allow users to keep and manage friend lists
@@ -70,7 +67,6 @@ prosody_external_modules:
   - s2s_auth_compat
   - s2s_blacklist
   - smacks
-  - smacks_offline
 
 prosody_external_modules_dir: /usr/local/share/prosody-modules
 
@@ -112,6 +108,7 @@ prosody_packages:
   - lua-sec
   - lua-bitop
   - lua-event
+  - lua-unbound
 
 # ldap
 prosody_ldap_packages:

--- a/templates/prosody.cfg.lua.j2
+++ b/templates/prosody.cfg.lua.j2
@@ -29,7 +29,7 @@ admins = {
 -- Enable use of libevent for better performance under high load
 -- For more information see: https://prosody.im/doc/libevent
 {% if prosody_libevent|default(True) %}
-use_libevent = true
+network_backend = "event"
 {% endif %}
 
 -- Prosody will always look in its source directory for modules, but
@@ -111,7 +111,7 @@ welcome_message = "{{ prosody_welcome_msg }}"
 {% endif %}
 
 {% if 'register_redirect' in prosody_external_modules %}
-registration_whitelist = { "{{ prosody_mod_register_redirect_registration_whitelist }}" }
+registration_allowlist = { "{{ prosody_mod_register_redirect_registration_allowlist }}" }
 registration_url = "{{ prosody_mod_register_redirect_registration_url }}"
 registration_text = "{{ prosody_mod_register_redirect_text }}"
 
@@ -199,9 +199,6 @@ s2s_secure_auth = false
 
 -- Required for init scripts and prosodyctl
 pidfile = "/var/run/prosody/prosody.pid"
-
--- let systemd daemonize the server
-daemonize = false
 
 -- Select the authentication backend to use. The 'internal' providers
 -- use Prosody's configured data storage to store the authentication data.
@@ -299,13 +296,6 @@ http_default_host = "{{ prosody_vhost }}"
 -- Register Web Template files
 register_web_template = "{{ prosody_custom_registration_theme_path }}"
 
-{% endif %}
-
-{% if prosody_cors %}
--- enable cross-domain requests
--- https://prosody.im/doc/setting_up_bosh#cross-domain_issues
-cross_domain_bosh = { "https://{{ prosody_vhost }}" }
-cross_domain_websocket = { "https://{{ prosody_vhost }}" }
 {% endif %}
 
 {% if 's2s_blacklist' in prosody_external_modules %}


### PR DESCRIPTION
  Messages fixed from config check:
    * Prosody was unable to find lua-unbound
    * You have some obsolete options you can remove from the global section:
      cross_domain_bosh, cross_domain_websocket
    *  You have some deprecated options in the global section:
      * 'use_libevent' -- instead, use 'network_backend = "event"'
      * 'registration_whitelist' -- instead, use 'registration_allowlist'
      * 'daemonize' -- instead, use the --daemonize/-D or --foreground/-F command line flags

  Messages fixed from syslog:
    * smacks_offline: mod_smacks_offline is deprecated! Just use mod_smacks!
    * pep_vcard_avatar: Please use mod_pep_simple instead of mod_pep to continue using this module
    * The 'daemonize' option has been deprecated, specify -D or -F on the command line instead.