### PR TITLE
switch to prosody plugin manager

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+
 prosody_vhost: localhost
 prosody_virtual_hosts:
   - name: "{{ prosody_vhost }}"
@@ -14,8 +15,10 @@ prosody_authentication: internal_hashed
 prosody_dhparam_length: 2048
 prosody_welcome_msg: "Hello $username, welcome to the $host IM server!"
 
+# https://prosody.im/doc/network_backend
 prosody_network_backend: '"epoll"'
 
+# https://prosody.im/doc/public_servers#scalability
 prosody_file_descriptor_limit: 10000
 
 # Set either a string, or a list of strings. If a list is given, the external
@@ -25,7 +28,7 @@ prosody_file_descriptor_limit: 10000
 # once and the module keeps track of who as seen which message.
 prosody_motd: []
 
-prosody_custom_registration_theme: False
+prosody_custom_registration_theme: false
 prosody_custom_registration_theme_repo: "https://github.com/beli3ver/Prosody-Web-Registration-Theme.git"
 prosody_custom_registration_theme_path: "/etc/prosody/register-templates/Prosody-Web-Registration-Theme"
 
@@ -35,6 +38,8 @@ prosody_mod_register_redirect_text: "To register please visit {{ prosody_mod_reg
 
 prosody_mod_register_min_seconds_between_registrations: 300  # requires a restart of the prosody server or module reload
 
+# prosody core modules
+# https://prosody.im/doc/modules
 prosody_modules:
   - admin_adhoc  # Allows administration via an XMPP client that supports ad-hoc commands
   - admin_telnet  # Opens telnet console interface on localhost port 5582
@@ -50,12 +55,15 @@ prosody_modules:
   - private  # Private XML storage (for room bookmarks, etc.)
   - roster  # Allow users to keep and manage friend lists
   - server_contact_info  # Publish contact information for this service
+  - smacks # allow clients to resume connection to server
   - tombstones # keep a record of accounts deleted accounts, ensure former contacts are aware, prevent re-registration
   - vcard4  # new vards standard
   - vcard_legacy  # Allow users to set vCards
   - welcome  # Welcome users who register accounts
   - websocket  # XMPP over WebSockets
 
+# Community modules which will be installed with plugin installer
+# see: https://prosody.im/doc/plugin_installer
 prosody_external_modules:
   - auto_activate_hosts
   - c2s_conn_throttle
@@ -71,12 +79,16 @@ prosody_external_modules:
   - register_web
   - s2s_auth_compat
   - s2s_blacklist
-  - smacks
+  - pep_vcard_avatar
 
-prosody_external_modules_dir: /usr/local/share/prosody-modules
+prosody_plugin_server: "https://modules.prosody.im/rocks/"
 
 prosody_muc_modules:
   - muc_mam  # Store MUC messages in an archive and allow users to access it
+
+# Community muc modules which will be installed with plugin installer
+# see: https://prosody.im/doc/plugin_installer
+prosody_muc_modules_extra:
   - vcard_muc  # adds the ability to set vCard for MUC rooms
 
 prosody_c2s_direct_tls_ports: 5223
@@ -109,10 +121,10 @@ prosody_clean_inactive_users: false
 
 prosody_packages:
   - prosody
-  - mercurial
   - lua-sec
   - lua-bitop
   - lua-unbound
+  - luarocks
 
 prosody_lua_version: "5.4"
 
@@ -123,10 +135,13 @@ prosody_ldap_packages:
   - lua-cyrussasl
 prosody_ldap_filter: (sAMAccountName=%u)
 
-# monitoring
+# monitoring with openmetrics endpoint
+# see: https://prosody.im/doc/modules/mod_http_openmetrics
 prosody_monitoring: true
+
 ## add prometheus server IP address here:
 prosody_openmetrics_allow_ips: '"127.0.0.1", "::1"'
+
 ## add IP addresses of interfaces on which to listen
 ## (e. g. for being scraped by prometheus):
 prosody_http_interfaces: '"127.0.0.1", "::1"'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -19,7 +19,7 @@
   ansible.builtin.systemd:
     name: prosody
     state: restarted
-    daemon_reload: yes
+    daemon_reload: true
 
 - name: stop prosody
   ansible.builtin.systemd:

--- a/tasks/prosody.yml
+++ b/tasks/prosody.yml
@@ -2,11 +2,14 @@
 
 - name: Ensure selected lua version is present
   ansible.builtin.apt:
-    pkg: "lua{{ prosody_lua_version }}"
+    pkg: "{{ item }}"
     cache_valid_time: 600
-  notify: 
+  loop:
+    - "lua{{ prosody_lua_version }}"
+    - "liblua{{ prosody_lua_version }}-dev"
+  notify:
     - update lua alternatives
-    - restart prosody 
+    - restart prosody
 
 - name: Ensure required packages are present
   ansible.builtin.apt:
@@ -43,14 +46,36 @@
     mode: 0640
   notify: reload prosody config
 
+- name: Flush handlers
+  ansible.builtin.meta: flush_handlers
+
 # - name: Create Prosody accounts
 #   ansible.builtin.command: prosodyctl register {{ item.name }} {{ prosody_virtual_domain }} {{ item.password }}
 #   with_items: prosody_accounts
 
-- name: Get latest prosody modules  # noqa 402
-  hg:
-    repo: https://hg.prosody.im/prosody-modules/
-    dest: "{{ prosody_external_modules_dir }}"
+- name: get installed prosody modules
+  ansible.builtin.command: prosodyctl list
+  changed_when: false
+  register: __prosody_installed_modules
+
+- name: ensure prosody modules are present
+  ansible.builtin.command: prosodyctl install mod_{{ item }}
+  loop: "{{ prosody_external_modules + prosody_muc_modules_extra | flatten(levels=1) }}"
+  when: __prosody_installed_modules.stdout_lines is not search(item)
+  notify:
+    - restart prosody
+
+- name: get outdated prosody modules
+  ansible.builtin.command: prosodyctl list --outdated
+  changed_when: false
+  register: __prosody_outdated_modules
+
+- name: ensure prosody modules are not outdated
+  ansible.builtin.command: prosodyctl install mod_{{ item }}
+  loop: "{{ prosody_external_modules + prosody_muc_modules_extra | flatten(levels=1) }}"
+  when: __prosody_outdated_modules.stdout_lines is search(item)
+  notify:
+    - restart prosody
 
 - include_tasks: tls.yml
   with_items: "{{ prosody_virtual_hosts }}"

--- a/templates/prosody.cfg.lua.j2
+++ b/templates/prosody.cfg.lua.j2
@@ -30,12 +30,8 @@ admins = {
 -- For more information see: https://prosody.im/doc/network_backend
 network_backend = {{ prosody_network_backend }}
 
--- Prosody will always look in its source directory for modules, but
--- this option allows you to specify additional locations where Prosody
--- will look for modules first. For community modules, see https://modules.prosody.im/
-plugin_paths = {
-	"{{ prosody_external_modules_dir }}"
-}
+-- server to load communit modules from
+plugin_server = "{{ prosody_plugin_server }}"
 
 -- This is the list of modules Prosody will load on startup.
 -- It looks for mod_modulename.lua in the plugins folder, so make sure that exists too.
@@ -91,7 +87,6 @@ modules_enabled = {
 		"turncredentials";
 {% endif %}
 }
-
 {% if prosody_motd %}
 motd_sequential_messages = {
 {% if prosody_motd is string %}
@@ -353,6 +348,9 @@ Component "conference.{{ vhost.name }}" "muc"
 	modules_enabled = {
 {% for module in prosody_muc_modules %}
 		"{{ module }}";
+{% endfor %}
+{% for module in prosody_muc_modules_extra %}
+                "{{ module }}";
 {% endfor %}
 	}
 	restrict_room_creation = "local"


### PR DESCRIPTION
Prosody 0.12 comes with a new plugin manager for community modules.
Some former community modules are now part of prosody core modules but are still/also in the mercurial repository.
This results in the module being there twice, which can be seen in the logs:

> modulemanager: Not loading module, due to conflicting features 'mod_bookmarks': /usr/local/share/prosody-modules/mod_bookmarks/mod_bookmarks.lua

The same applies for mod_smacks which underwent a lot of changes but is loaded from the mercurial repo where it isn't updated anymore.

To use the core modules the easiest way is to not clone the mercurial repo but to migrate to
use the new plugin manager and only add/install needed community modules. 

This way the plugins can also easily updated (which can be checked via ansible --check run).

The installation dir of the plugins via plugin manager is `/var/lib/prosody/custom_plugins` and the old plugin dir (`/usr/local/share/prosody/custom_plugins`) is not touched but not used anymore.

This is, if ervything goes according to plan, not a breaking change but will update outdated plugins, so things may break.
Maybe consider a major version bump.
