### PR TITLE
fix external module handling for turnserver, motd and external_services. Make external module update configurable. Add vars for molecule test to make the testing more complete. Fix check_mode

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,6 +81,11 @@ prosody_external_modules:
   - s2s_blacklist
   - pep_vcard_avatar
 
+# set to false if external modules should not be updated
+prosody_update_external_modules: true
+# exclude individual external modules from updates
+prosody_update_external_modules_ignore: []
+
 prosody_plugin_server: "https://modules.prosody.im/rocks/"
 
 prosody_muc_modules:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,5 +13,17 @@ lint: |
 provisioner:
   name: ansible
   become: true
+  inventory:
+    group_vars:
+      all:
+        prosody_motd: [Hello]
+        prosody_clean_inactive_users: true
+        prosody_turncredentials_host: turn0.example.org
+        prosody_turncredentials_secret: "secret"
+        prosody_external_services:
+          - uri: turn0.example.org
+            port: 3478
+            transport: udp
+            type: stun
 verifier:
   name: goss

--- a/tasks/prosody.yml
+++ b/tasks/prosody.yml
@@ -56,24 +56,36 @@
 - name: get installed prosody modules
   ansible.builtin.command: prosodyctl list
   changed_when: false
+  check_mode: false
   register: __prosody_installed_modules
+
+- name: assemble external module list to install and enable
+  ansible.builtin.set_fact: __prosody_extra_modules="{{ __prosody_extra_modules | default([]) + prosody_external_modules | default([]) + prosody_muc_modules_extra | default([]) }}{% if prosody_motd and not prosody_motd is string %} + [ 'motd_sequential']{% endif %}{% if prosody_external_services is defined %} + ['extdisco'] {% endif %}{% if prosody_turncredentials_host is defined and prosody_turncredentials_secret is defined %} + ['turncredentials']{% endif %}"
 
 - name: ensure prosody modules are present
   ansible.builtin.command: prosodyctl install mod_{{ item }}
-  loop: "{{ prosody_external_modules + prosody_muc_modules_extra | flatten(levels=1) }}"
-  when: __prosody_installed_modules.stdout_lines is not search(item)
+  loop: "{{ __prosody_extra_modules | flatten(levels=1) }}"
+  when:
+    - __prosody_installed_modules.stdout_lines is not search(item)
+    - __prosody_extra_modules
   notify:
     - restart prosody
 
 - name: get outdated prosody modules
   ansible.builtin.command: prosodyctl list --outdated
   changed_when: false
+  check_mode: false
   register: __prosody_outdated_modules
+  when: prosody_update_external_modules
 
 - name: ensure prosody modules are not outdated
   ansible.builtin.command: prosodyctl install mod_{{ item }}
-  loop: "{{ prosody_external_modules + prosody_muc_modules_extra | flatten(levels=1) }}"
-  when: __prosody_outdated_modules.stdout_lines is search(item)
+  loop: "{{ __prosody_extra_modules | flatten(levels=1) }}"
+  when:
+    - __prosody_outdated_modules.stdout_lines | default() is search(item)
+    - __prosody_extra_modules
+    - prosody_update_external_modules
+    - prosody_update_external_modules_ignore is not search(item)
   notify:
     - restart prosody
 

--- a/templates/prosody.cfg.lua.j2
+++ b/templates/prosody.cfg.lua.j2
@@ -72,7 +72,6 @@ modules_enabled = {
 		"{{ module }}";
 {% endfor %}
 
-
 	-- External
 {% for module in prosody_external_modules %}
 		"{{ module }}";


### PR DESCRIPTION
some external modules with special uses cases were missed in tha last PR. fixed this now
and expanded the molecule test to also test them.

Check mode got broken with the last PR, fixed now.

Made the external modules handling more flexible to e .g. not update the modules
or exclude individual ones from updates.

A molecule check for the check mode would be cool to implement, but couldn't
figure out how to do this quickly. Maybe @t2d you know how this could be implemented?
